### PR TITLE
Added an option to specify coroot Kubernetes Service annotations.

### DIFF
--- a/charts/coroot/templates/service.yaml
+++ b/charts/coroot/templates/service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "coroot.fullname" . }}
+  {{- with .Values.corootCE.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "coroot.labels" . | nindent 4 }}
 spec:

--- a/charts/coroot/values.yaml
+++ b/charts/coroot/values.yaml
@@ -27,6 +27,7 @@ corootCE:
   service:
     type: ClusterIP
     port: 8080
+    annotations: {}
   ingress:
     enabled: false
     className: ""


### PR DESCRIPTION
Service for coroot doesn't have the option to add custom annotations through Helm values.
One example where service annotations are needed is GKE Container Native Load Balancing which requires `cloud.google.com/neg: '{"ingress": true}' `  annotation.
