### PR TITLE
priorityclassname parameter for node-agent

### DIFF
--- a/charts/node-agent/templates/daemonset.yaml
+++ b/charts/node-agent/templates/daemonset.yaml
@@ -26,6 +26,7 @@ spec:
       {{- end }}
       tolerations:
         - operator: Exists
+      priorityClassName: {{ .Values.priorityClassName }}
       hostPID: true
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/node-agent/values.yaml
+++ b/charts/node-agent/values.yaml
@@ -9,6 +9,8 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
+priorityClassName: ""
+
 resources:
   requests:
     cpu: "100m"


### PR DESCRIPTION
By setting priorityClassName on a DaemonSet, you can assign a higher priority to the Pods managed by the DaemonSet, which ensures that they receive preferential treatment in resource allocation and scheduling. This can be especially important for critical system-level services that need to be highly available and responsive.