### PR TITLE
aws-agent - serviceaccount resource creation and priorityclass handling

### DIFF
--- a/charts/aws-agent/templates/_helpers.tpl
+++ b/charts/aws-agent/templates/_helpers.tpl
@@ -49,3 +49,14 @@ Selector labels
 app.kubernetes.io/name: {{ include "aws-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aws-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "aws-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/aws-agent/templates/deployment.yaml
+++ b/charts/aws-agent/templates/deployment.yaml
@@ -24,9 +24,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccountName }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "aws-agent.serviceAccountName" . }}
+      priorityClassName: {{ .Values.priorityClassName }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/aws-agent/templates/serviceaccount.yaml
+++ b/charts/aws-agent/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aws-agent.serviceAccountName" . }}
+  labels:
+    {{- include "aws-agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/aws-agent/values.yaml
+++ b/charts/aws-agent/values.yaml
@@ -11,8 +11,6 @@ rds:
 ec:
   filter: ""
 
-serviceAccountName: ""
-
 replicaCount: 1
 
 image:
@@ -33,6 +31,17 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+priorityClassName: ""
 
 nodeSelector: {}
 


### PR DESCRIPTION
I've created two updates to the coroot-aws-agent:
1. Helm can now create ServiceAccount resource, not only used created one.
2. Added the ability to set PriorityClass to deployment - enhances workload management and stability.
