### PR TITLE
feat: Support pod monitor when installing node-agent charts separately

### DIFF
--- a/charts/node-agent/templates/podmonitor.yaml
+++ b/charts/node-agent/templates/podmonitor.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.podMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: coroot-node-agent
+  {{- if .Values.podMonitor.labels }}
+  labels:
+  {{ .Values.podMonitor.labels | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: coroot-node-agent
+  podMetricsEndpoints:
+    - port: http
+{{- end -}}

--- a/charts/node-agent/values.yaml
+++ b/charts/node-agent/values.yaml
@@ -32,3 +32,7 @@ scrapeInterval: ""
 tracesEndpoint: ""
 logsEndpoint: ""
 profilesEndpoint: ""
+
+podMonitor:
+  enabled: false
+  labels: {}


### PR DESCRIPTION
Support the configuration of pod monitoring when installing node-agent charts separately. Also, the configuration of labels supports automatic scraping in the case of `kube prometheus stack`.
For example, 
```
labels: 
  release: kube-prom-stack
```