### PR TITLE
Add affinity configuration to node-agent DaemonSet

### DIFF
--- a/charts/node-agent/templates/_helpers.tpl
+++ b/charts/node-agent/templates/_helpers.tpl
@@ -49,3 +49,13 @@ Selector labels
 app.kubernetes.io/name: {{ include "node-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Affinity for pod assignment
+*/}}
+{{- define "node-agent.affinity" -}}
+{{- with .Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/node-agent/templates/daemonset.yaml
+++ b/charts/node-agent/templates/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "node-agent.affinity" . | nindent 6 }}
       tolerations:
         - operator: Exists
       priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/node-agent/values.yaml
+++ b/charts/node-agent/values.yaml
@@ -32,3 +32,13 @@ scrapeInterval: ""
 tracesEndpoint: ""
 logsEndpoint: ""
 profilesEndpoint: ""
+
+affinity: {}
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #       - matchExpressions:
+  #           - key: eks.amazonaws.com/compute-type
+  #             operator: NotIn
+  #             values:
+  #               - fargate


### PR DESCRIPTION

## Description
This PR adds the ability to configure affinity for the node-agent DaemonSet using Helm values. This enhancement allows users to specify node affinity rules, which can be useful for targeting specific nodes or node types in a Kubernetes cluster.

## Changes
- Updated `daemonset.yaml` to include affinity configuration
- Modified `values.yaml` to add an `affinity` section with examples
- Added a new helper template in `_helpers.tpl` for affinity

## How to use
Users can now specify affinity rules in their `values.yaml` file when deploying the node-agent. For example:
