### PR TITLE
Fixed the selection of the correct secret and key for the coroot deployment if an existingSecret for clickhouse is used

### DIFF
--- a/charts/coroot/templates/deployment.yaml
+++ b/charts/coroot/templates/deployment.yaml
@@ -48,18 +48,18 @@ spec:
           {{- if and .Values.clickhouse.enabled }}
             - name: BOOTSTRAP_CLICKHOUSE_ADDRESS
               value: {{ printf "%s:%s" (include "coroot.clickhouse.fullname" .) (.Values.clickhouse.service.ports.tcp | toString ) }}
-            {{- if not .Values.clickhouse.auth.existingSecret }}
-            - name: BOOTSTRAP_CLICKHOUSE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "coroot.clickhouse.fullname" . }}
-                  key: "admin-password"
-            {{- else if .Values.clickhouse.auth.existingSecret }}
+            {{- if .Values.clickhouse.auth.existingSecret }}
             - name: BOOTSTRAP_CLICKHOUSE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.clickhouse.auth.existingSecret }}
                   key: {{ .Values.clickhouse.auth.existingSecretKey }}
+            {{- else }}
+            - name: BOOTSTRAP_CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "coroot.clickhouse.fullname" . }}
+                  key: "admin-password"
             {{- end }}
             - name: BOOTSTRAP_CLICKHOUSE_USER
               value: {{ .Values.corootCE.bootstrap.clickhouse.username }}

--- a/charts/coroot/templates/deployment.yaml
+++ b/charts/coroot/templates/deployment.yaml
@@ -48,11 +48,19 @@ spec:
           {{- if and .Values.clickhouse.enabled }}
             - name: BOOTSTRAP_CLICKHOUSE_ADDRESS
               value: {{ printf "%s:%s" (include "coroot.clickhouse.fullname" .) (.Values.clickhouse.service.ports.tcp | toString ) }}
+            {{- if not .Values.clickhouse.auth.existingSecret }}
             - name: BOOTSTRAP_CLICKHOUSE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "coroot.clickhouse.fullname" . }}
                   key: "admin-password"
+            {{- else if .Values.clickhouse.auth.existingSecret }}
+            - name: BOOTSTRAP_CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.auth.existingSecret -}}
+                  key: {{ .Values.clickhouse.auth.existingSecretKey }}
+            {{- end }}
             - name: BOOTSTRAP_CLICKHOUSE_USER
               value: {{ .Values.corootCE.bootstrap.clickhouse.username }}
             - name: BOOTSTRAP_CLICKHOUSE_DATABASE

--- a/charts/coroot/templates/deployment.yaml
+++ b/charts/coroot/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - name: BOOTSTRAP_CLICKHOUSE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.clickhouse.auth.existingSecret -}}
+                  name: {{ .Values.clickhouse.auth.existingSecret }}
                   key: {{ .Values.clickhouse.auth.existingSecretKey }}
             {{- end }}
             - name: BOOTSTRAP_CLICKHOUSE_USER

--- a/charts/coroot/values.yaml
+++ b/charts/coroot/values.yaml
@@ -424,12 +424,15 @@ clickhouse:
   shards: 1
   zookeeper:
     enabled: false
+  auth:
+    existingSecret: ""
+    existingSecretKey: ""
   extraOverrides: |
     <clickhouse>
       <asynchronous_metric_log remove="1"/>
       <metric_log remove="1"/>
       <query_log remove="1" />
-      <query_thread_log remove="1" />  
+      <query_thread_log remove="1" />
       <query_views_log remove="1" />
       <part_log remove="1"/>
       <text_log remove="1" />


### PR DESCRIPTION
Fixed the selection of the correct secret and key for the coroot deployment if an existingSecret for clickhouse is used