### PR TITLE
Add some useful configs for operator helm chart

### DIFF
--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coroot-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: coroot-operator
 spec:
@@ -10,14 +11,37 @@ spec:
       app.kubernetes.io/name: coroot-operator
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: coroot-operator
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
-        runAsNonRoot: true
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: coroot-operator
       containers:
         - name: operator
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      serviceAccountName: coroot-operator
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
         - name: operator
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"

--- a/charts/operator/templates/role_binding.yaml
+++ b/charts/operator/templates/role_binding.yaml
@@ -9,6 +9,6 @@ roleRef:
   kind: ClusterRole
   name: coroot-operator
 subjects:
-- kind: ServiceAccount
-  name: coroot-operator
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: { { .Values.serviceAccount.name } }
+    namespace: { { .Release.Namespace } }

--- a/charts/operator/templates/service_account.yaml
+++ b/charts/operator/templates/service_account.yaml
@@ -1,6 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: coroot-operator
-  name: coroot-operator
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -1,7 +1,44 @@
+## Service Account configuration
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  name: "coroot-operator"
+
 image:
   repository: ghcr.io/coroot/coroot-operator
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
 
 resources:
   requests:
     cpu: 100m
     memory: 64Mi
+
+## Extra annotations for pods
+podAnnotations: {}
+
+## Configure Pods Security Context
+podSecurityContext:
+  runAsNonRoot: true
+
+## Configure Container Security Context
+containerSecurityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+## Node labels selector for pods assignment
+nodeSelector: {}
+
+## Tolerations for pods assignment
+tolerations: []
+
+## Affinity for pods assignment
+affinity: {}


### PR DESCRIPTION
Hi,

I'm very appreciate that you have published the Operator deployment method to be used for Kubernetes.

I've noticed that your helm chart for Coroot-Operator is missing some configurable parameters that might be required for some environments (at least my current environment) such as `nodeSelector`, `annotations`, and `imagePullSecrets`. So I create this PR to contribute some of these parameters to your Coroot-Operator Helm Chart.

Hope it will help!