### PR TITLE
feat: coroot - add custom initContainers

### DIFF
--- a/charts/coroot/templates/deployment.yaml
+++ b/charts/coroot/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       serviceAccountName: {{ include "coroot.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.corootCE.podSecurityContext | nindent 8 }}
+      {{- if .Values.corootCE.initContainers }}
+      initContainers:
+        {{- toYaml .Values.corootCE.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/coroot/values.yaml
+++ b/charts/coroot/values.yaml
@@ -13,6 +13,28 @@ corootCE:
     pullPolicy: IfNotPresent
     tag: ""
   imagePullSecrets: []
+  initContainers: []
+    # - name: init-chown
+    #   image: busybox
+    #   securityContext:
+    #     runAsNonRoot: false
+    #     runAsUser: 0
+    #   resources:
+    #     limits:
+    #       cpu: 100m
+    #       memory: 128Mi
+    #     requests:
+    #       cpu: 50m
+    #       memory: 64Mi
+    #   command: ['sh']
+    #   args:
+    #     - "-c"
+    #     - |
+    #       set -ex
+    #       chown 1000:2000 /data
+    #   volumeMounts:
+    #     - name: data
+    #       mountPath: /data
   nameOverride: ""
   fullnameOverride: ""
   serviceAccount:
@@ -28,7 +50,7 @@ corootCE:
     #   - ALL
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
-  # runAsUser: 1000
+    # runAsUser: 1000
   service:
     type: ClusterIP
     port: 8080


### PR DESCRIPTION
Add custom initContainers for coroot chart for fix permission error of data directory if set values of `podSecurityContext` and `securityContext`:
```
...
  podSecurityContext:
    fsGroup: 2000
  securityContext:
    capabilities:
      drop:
        - ALL
    readOnlyRootFilesystem: true
    runAsNonRoot: true
    runAsUser: 1000
...
```
For example `init-chown` init container:
```
  initContainers:
    - name: init-chown
      image: busybox
      securityContext:
        runAsNonRoot: false
        runAsUser: 0
      resources:
        limits:
          cpu: 100m
          memory: 128Mi
        requests:
          cpu: 50m
          memory: 64Mi
      command: ['sh']
      args:
        - "-c"
        - |
          set -ex
          chown 1000:2000 /data
      volumeMounts:
        - name: data
          mountPath: /data
```