### PR TITLE
feat(coroot): add statefulset for correct support HA mode.

### DIFF
--- a/charts/coroot/templates/pvc.yaml
+++ b/charts/coroot/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.corootCE.enabled -}}
+{{- if and .Values.corootCE.enabled (not .Values.corootCE.useStatefulSet) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/coroot/templates/statefulset.yaml
+++ b/charts/coroot/templates/statefulset.yaml
@@ -1,14 +1,13 @@
-{{- if and .Values.corootCE.enabled (not .Values.corootCE.useStatefulSet) -}}
+{{- if and .Values.corootCE.enabled .Values.corootCE.useStatefulSet -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "coroot.fullname" . }}
   labels:
     {{- include "coroot.labels" . | nindent 4 }}
 spec:
-  replicas: 1
-  strategy:
-    {{- toYaml .Values.corootCE.strategy | nindent 4 }}
+  serviceName: "{{ include "coroot.fullname" . }}"
+  replicas: {{ .Values.corootCE.replicas }}
   selector:
     matchLabels:
       {{- include "coroot.selectorLabels" . | nindent 6 }}
@@ -86,10 +85,18 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: data
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: {{ template "coroot.fullname" . }}-data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: 
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: {{ .Values.corootCE.persistentVolume.size | quote }}
+      {{- with .Values.corootCE.persistentVolume.storageClassName }}
+        storageClassName: {{ . }}
+      {{- end }}
       {{- with .Values.corootCE.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/coroot/values.yaml
+++ b/charts/coroot/values.yaml
@@ -1,10 +1,14 @@
 corootCE:
   enabled: true
+  # useStatefulSet - Only for HA mode when use PostgreSQL
+  # https://docs.coroot.com/configuration/high-availability
+  useStatefulSet: false
   bootstrap:
     refreshInterval: 15s
     clickhouse:
       database: default
       username: default
+  # replicas - can set more 1 when set `useStatefulSet: true`
   replicas: 1
   strategy:
     type: Recreate


### PR DESCRIPTION
* Added statefulSet support for deploying coroot in HA mode when using PostgreSQL.
* In deployment configuration, replicaCount hardcoded 1, because ReadWriteOnce does not support mounting the PersistentVolume to more than one pod.

