### PR TITLE
fix: coroot - correct use digest for corootConnect and corootClusterAgent images

### DIFF
--- a/charts/coroot/templates/_helpers.tpl
+++ b/charts/coroot/templates/_helpers.tpl
@@ -77,7 +77,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "corootConnect.labels" -}}
 helm.sh/chart: {{ include "coroot.chart" . }}
 {{ include "corootConnect.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.corootConnect.image.tag | quote }}
+app.kubernetes.io/version: {{ regexReplaceAll "@.*$" .Values.corootConnect.image.tag "" | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -98,7 +98,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "corootClusterAgent.labels" -}}
 helm.sh/chart: {{ include "coroot.chart" . }}
 {{ include "corootClusterAgent.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.corootClusterAgent.image.tag | quote }}
+app.kubernetes.io/version: {{ regexReplaceAll "@.*$" .Values.corootClusterAgent.image.tag "" | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 


### PR DESCRIPTION
If set:
```yaml
corootClusterAgent:
  enabled: true
...
  image:
    repository: ghcr.io/coroot/coroot-cluster-agent
    pullPolicy: IfNotPresent
    tag: "1.2.4@sha256:147f409753e9482bfbba27453780cb8a13b3aa69946873e28ee2ce5c58733c71"
```
digest will used in the `app.kubernetes.io/version` label:
```bash
 helm template -f values.yaml . | grep app.kubernetes.io/version | grep 1.2.4
    app.kubernetes.io/version: "1.2.4@sha256:147f409753e9482bfbba27453780cb8a13b3aa69946873e28ee2ce5c58733c71"
    app.kubernetes.io/version: "1.2.4@sha256:147f409753e9482bfbba27453780cb8a13b3aa69946873e28ee2ce5c58733c71"
    app.kubernetes.io/version: "1.2.4@sha256:147f409753e9482bfbba27453780cb8a13b3aa69946873e28ee2ce5c58733c71"
    app.kubernetes.io/version: "1.2.4@sha256:147f409753e9482bfbba27453780cb8a13b3aa69946873e28ee2ce5c58733c71"
```