### PR TITLE
chart(operator): add configurable podLabels

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: coroot-operator
 description: A Helm chart to deploy the Coroot Operator for Kubernetes
 type: application
-version: 0.9.4
+version: 0.9.5
 appVersion: "1.9.3"

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       {{- end }}
       labels:
         app.kubernetes.io/name: coroot-operator
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -25,6 +25,9 @@ resources:
 ## Extra annotations for pods
 podAnnotations: {}
 
+## Extra labels for pods
+podLabels: {}
+
 ## Configure Pods Security Context
 podSecurityContext:
   runAsNonRoot: true


### PR DESCRIPTION
## Problem

The operator labels every resource it manages (Coroot pods, ClickHouse pods, etc.) with `app.kubernetes.io/part-of: coroot`, but the operator's own pod doesn't carry any of those labels. There's no way today to add custom labels to the operator pod without forking the chart.

## Solution

Add a `podLabels: {}` value to the operator chart, merged into the pod template's labels. Mirrors the existing `podAnnotations` pattern in the same chart.

Users who want to add labels can now set - 

```yaml
podLabels:
  app: coroot
  squad: observability
```

Selector and default labels are unchanged — backward compatible. Chart bumped `0.9.4` → `0.9.5`.
